### PR TITLE
Add support page link on index

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,7 @@
         <span>© <span id="y"></span> RunPacer</span>
         <span>
           <a href="privacy.html">Politique de confidentialité</a> ·
+          <a href="support.html">Support</a> ·
           <a href="mailto:runpacer.app@gmail.com">Contact</a>
         </span>
       </div>


### PR DESCRIPTION
## Summary
- add Support page link in footer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e89e74878832ba22cbafdb44163e8