### PR TITLE
Add favicon to RunPacer site

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://joreach3023.github.io/runpacer/">
   <meta property="og:image" content="https://joreach3023.github.io/runpacer/assets/og-cover.png">
-  <link rel="icon" href="assets/favicon.png">
+  <link rel="icon" type="image/png" href="assets/favicon.png">
   <style>
     :root{
       --bg:#0b1020; --txt:#e9eef6; --muted:#b6c1d1; --card:#121a33; --brand:#3498db; --ok:#2ecc71; --warn:#e67e22;

--- a/privacy.html
+++ b/privacy.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>Politique de confidentialité – RunPacer</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" type="image/png" href="assets/favicon.png">
   <style>
     body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;max-width:860px;margin:0 auto;padding:24px;line-height:1.6}
     h1,h2{line-height:1.25} code,pre{background:#f6f8fa;padding:.2em .4em;border-radius:4px}

--- a/support.html
+++ b/support.html
@@ -5,7 +5,7 @@
   <title>Support – RunPacer</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Assistance et FAQ pour l’application RunPacer : dépannage GPS, Strava, notifications, confidentialité et contact.">
-  <link rel="icon" href="assets/favicon.png">
+  <link rel="icon" type="image/png" href="assets/favicon.png">
   <style>
     :root{--bg:#0b1020;--txt:#e9eef6;--muted:#b6c1d1;--card:#121a33;--brand:#3498db;--ok:#2ecc71;--warn:#e67e22}
     *{box-sizing:border-box} body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:var(--txt);background:linear-gradient(180deg,#0b1020,#0d1430 40%,#0f183a)}


### PR DESCRIPTION
## Summary
- include favicon link on all HTML pages so the RunPacer icon shows in the browser tab

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e8c921038832b8b61290d6e065e3c